### PR TITLE
Fix a crash

### DIFF
--- a/WindowsGSM-Plugin-Development/WindowsGSM-Plugin-Development.csproj
+++ b/WindowsGSM-Plugin-Development/WindowsGSM-Plugin-Development.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>1998;</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>1998;</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/WindowsGSM/GameServer/Query/A2S.cs
+++ b/WindowsGSM/GameServer/Query/A2S.cs
@@ -230,7 +230,7 @@ namespace WindowsGSM.GameServer.Query
             try
             {
                 Dictionary<string, string> kv = await GetInfo();
-                return kv["Players"] + '/' + kv["MaxPlayers"];
+                return kv?["Players"] + '/' + kv?["MaxPlayers"];
             }
             catch
             {

--- a/WindowsGSM/GameServer/Query/FIVEM.cs
+++ b/WindowsGSM/GameServer/Query/FIVEM.cs
@@ -72,7 +72,7 @@ namespace WindowsGSM.GameServer.Query
             try
             {
                 Dictionary<string, string> kv = await GetInfo();
-                return kv["clients"] + '/' + kv["sv_maxclients"];
+                return kv?["clients"] + '/' + kv?["sv_maxclients"];
             }
             catch
             {

--- a/WindowsGSM/GameServer/Query/UT3.cs
+++ b/WindowsGSM/GameServer/Query/UT3.cs
@@ -110,7 +110,7 @@ namespace WindowsGSM.GameServer.Query
             try
             {
                 Dictionary<string, string> kv = await GetInfo();
-                return kv["Players"] + '/' + kv["MaxPlayers"];
+                return kv?["Players"] + '/' + kv?["MaxPlayers"];
             }
             catch
             {


### PR DESCRIPTION
This fixes a potential crash when the program tries to query the server info when the server is no longer running, GetInfo will return a null Dictionary causing a null reference exception, so we add a null conditional to check for this