### PR TITLE
Fix Remote Version Not Populating

### DIFF
--- a/WindowsGSM/Installer/SteamCMD.cs
+++ b/WindowsGSM/Installer/SteamCMD.cs
@@ -32,7 +32,7 @@ namespace WindowsGSM.Installer
             Directory.CreateDirectory(_installPath);
             var exePath = Path.Combine(_installPath, _exeFile);
             if (File.Exists(exePath)) { return true; }
-            
+
             try
             {
                 var zipPath = Path.Combine(_installPath, "steamcmd.zip");
@@ -82,7 +82,7 @@ namespace WindowsGSM.Installer
                         {
                             steamUser = keyvalue[1].Trim('\"');
                         }
-                        else if(keyvalue[0] == "steamPass")
+                        else if (keyvalue[0] == "steamPass")
                         {
                             steamPass = keyvalue[1].Trim('\"');
                         }
@@ -103,7 +103,7 @@ namespace WindowsGSM.Installer
             }
 
             _param += (string.IsNullOrWhiteSpace(modName) ? string.Empty : $" +app_set_config 90 mod {modName}") + $" +app_update {appId}" + (validate ? " validate" : "");
-            
+
             if (appId == "90")
             {
                 //Install 4 more times if hlds.exe
@@ -429,7 +429,7 @@ namespace WindowsGSM.Installer
                 {
                     FileName = exePath,
                     //Sometimes it fails to get if appID < 90
-                    Arguments = $"+login anonymous +app_info_update 1 +app_info_print {appId} +app_info_print {appId} +app_info_print {appId} +app_info_print {appId} +quit",
+                    Arguments = $"+login anonymous +app_info_update 1 +app_info_print {appId} +app_info_print {appId} +app_info_print {appId} +app_info_print {appId} +logoff +quit",
                     WindowStyle = ProcessWindowStyle.Minimized,
                     CreateNoWindow = true,
                     UseShellExecute = false,


### PR DESCRIPTION
Fixes the Remote Build Version not populating due to steamcmd closing before getting the info. adding the logoff allows gsm to get the info and populate the remote build version

-sorry had to redo it as other stuff got drawn in, should be good now